### PR TITLE
Improved the ParameterBagInterface.

### DIFF
--- a/ParameterBag/ParameterBagInterface.php
+++ b/ParameterBag/ParameterBagInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\ParameterBag;
 
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 
 /**
@@ -25,6 +26,8 @@ interface ParameterBagInterface
     /**
      * Clears all parameters.
      *
+     * @throws LogicException if the ParameterBagInterface can not be cleared
+     *
      * @api
      */
     public function clear();
@@ -33,6 +36,8 @@ interface ParameterBagInterface
      * Adds parameters to the service container parameters.
      *
      * @param array $parameters An array of parameters
+     *
+     * @throws LogicException if the parameter can not be added
      *
      * @api
      */
@@ -66,6 +71,8 @@ interface ParameterBagInterface
      * @param string $name  The parameter name
      * @param mixed  $value The parameter value
      *
+     * @throws LogicException if the parameter can not be set
+     *
      * @api
      */
     public function set($name, $value);
@@ -80,6 +87,17 @@ interface ParameterBagInterface
      * @api
      */
     public function has($name);
+
+    /**
+     * Removes a parameter.
+     *
+     * @param string $name The parameter name
+     *
+     * @throws LogicException if the parameter can not be removed
+     *
+     * @api
+     */
+    public function remove($name);
 
     /**
      * Replaces parameter placeholders (%name%) by their values for all parameters.


### PR DESCRIPTION
The ParameterBagInterface was missing some @throws annotations, so the FrozenParameterBag class was a violation of Liskov subtitution principle. Also the ParameterBagInterface was missing the remove method.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 